### PR TITLE
fix: LayerX (2026/04~) の職種を SRE から SWE に修正

### DIFF
--- a/src/data/workHistory.json
+++ b/src/data/workHistory.json
@@ -52,6 +52,6 @@
   {
     "company": "株式会社LayerX",
     "period": "2026/04~",
-    "description": "バクラク事業部SRE"
+    "description": "バクラク事業部SWE"
   }
 ]


### PR DESCRIPTION
## Summary
- `src/data/workHistory.json` の LayerX (2026/04~) エントリの description を `バクラク事業部SRE` → `バクラク事業部SWE` に修正

## Test plan
- [ ] ポートフォリオサイトの職務経歴セクションで LayerX の職種が SWE と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)