### PR TITLE
feat: News ページを Works ルートにリネーム（/news → /works）

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,16 @@ const nextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async redirects() {
+    return [
+      // 旧 /news を /works へ恒久リダイレクト（既存リンク・SEO対策）
+      {
+        source: '/news',
+        destination: '/works',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,14 +93,14 @@ export default function Header() {
             Services
           </Heading>
         </Link>
-        <Link href="/news" passHref>
+        <Link href="/works" passHref>
           <Heading
             fontSize={'2xl'}
             as="b"
             display={{ base: 'block' }}
-            color={router.pathname === '/news' ? 'gray.900' : 'whiteAlpha.900'}
+            color={router.pathname === '/works' ? 'gray.900' : 'whiteAlpha.900'}
             role="menuitem"
-            aria-current={router.pathname === '/news' ? 'page' : undefined}
+            aria-current={router.pathname === '/works' ? 'page' : undefined}
             tabIndex={0}
           >
             Works

--- a/src/pages/works.tsx
+++ b/src/pages/works.tsx
@@ -8,11 +8,11 @@ const news: NewsObj[] = newsData
   .sort((a, b) => b.date.getTime() - a.date.getTime())
 
 export default function NewsPage() {
-  // ニュースページ用の構造化データ
+  // Works ページ用の構造化データ
   const newsStructuredData = {
     '@context': 'https://schema.org',
     '@type': 'Blog',
-    headline: 'IY Tech ニュース',
+    headline: 'IY Tech Works',
     description: 'IY Techの活動やプロジェクトに関する最新情報をお届けします。',
     author: {
       '@type': 'Person',
@@ -38,9 +38,16 @@ export default function NewsPage() {
   return (
     <div>
       <Seo
-        pageTitle="ニュース"
-        pageDescription="IY Techの活動やプロジェクトに関する最新情報をお届けします。受賞歴やイベント参加など、さまざまな活動をご紹介します。"
-        pageKeywords={['ニュース', '受賞歴', 'イベント', 'セミナー']}
+        pageTitle="Works"
+        pageDescription="IY Techの開発実績や活動をご紹介します。サービス開発・受賞歴・イベント登壇など、さまざまな取り組みをまとめています。"
+        pageKeywords={[
+          '実績',
+          'Works',
+          '開発事例',
+          '受賞歴',
+          'イベント',
+          'セミナー',
+        ]}
         pageType="article"
         structuredData={newsStructuredData}
       />


### PR DESCRIPTION
## 概要
Works 表記の統一として、`/news` ルートを `/works` にリネームしました。

## 変更内容
- `src/pages/news.tsx` → `src/pages/works.tsx` にリネーム（ルートが `/works` に）
- ページタイトル・構造化データの表記を「Works」に更新
- ヘッダーのナビリンク先・active 判定を `/works` に変更
- 旧 `/news` → `/works` の恒久リダイレクトを `next.config.js` に追加（既存リンク・SEO対策）

## 確認
- `npm run build` 成功（ルートが `/works` で生成）
- tsc 型エラー 0 / prettier 準拠
- ブラウザでタイトル「Works | IY Tech | ポートフォリオ」を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)