### PR TITLE
fix: モバイルUI調整（iOS入力ズーム抑止・ハンバーガーメニューのマージン）

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -106,7 +106,9 @@ export default function Header() {
             Works
           </Heading>
         </Link>
-        <RequirementsHearingChat onOpen={() => onClose()} />
+        <Box mt={{ base: 4, md: 0 }}>
+          <RequirementsHearingChat onOpen={() => onClose()} />
+        </Box>
       </Stack>
       <Box
         display={{ base: open ? 'block' : 'none', md: 'block' }}

--- a/src/components/RequirementsHearingChat.tsx
+++ b/src/components/RequirementsHearingChat.tsx
@@ -326,6 +326,7 @@ export default function RequirementsHearingChat({ onOpen, trigger }: Props) {
                 disabled={done}
                 borderRadius="full"
                 bg="gray.50"
+                fontSize="16px"
               />
               <IconButton
                 aria-label="送信"


### PR DESCRIPTION
## 概要
スマホ表示時のUIを2点調整しました。

## 変更内容
- **iOS入力ズーム抑止**: AIアシスタント（要件ヒアリング）の入力欄に `fontSize="16px"` を指定。iOS Safari は入力欄のフォントサイズが16px未満だとフォーカス時に自動ズームするため、これを抑止しました（ビューポート固定でピンチズームを殺す方法より推奨される対処）。
- **ハンバーガーメニューのマージン**: メニュー内の要件ヒアリングボタンに上マージン（`mt={4}`、`base` のみ）を追加。`md` 以上の横並び表示では `0` のままなのでデスクトップの見た目は変わりません。

## 影響範囲
- `src/components/RequirementsHearingChat.tsx`
- `src/components/Header.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)